### PR TITLE
API:V1 spelling error fixed

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,4 @@
-class Api::v1::UsersController < ApiController
+class Api::V1::UsersController < ApiController
   def index
     render json: User.all
   end


### PR DESCRIPTION
Spelling causing Heroku to not deploy